### PR TITLE
fix: errors in publish should throw a SemanticReleaseError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.1.37",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.2.2"
+        "@adobe/fetch": "4.2.2",
+        "@semantic-release/error": "4.0.0"
       },
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.9",
@@ -793,6 +794,16 @@
         "semantic-release": ">=18.0.0"
       }
     },
+    "node_modules/@semantic-release/changelog/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-13.0.0.tgz",
@@ -816,12 +827,12 @@
       }
     },
     "node_modules/@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=14.17"
+        "node": ">=18"
       }
     },
     "node_modules/@semantic-release/git": {
@@ -844,6 +855,16 @@
       },
       "peerDependencies": {
         "semantic-release": ">=18.0.0"
+      }
+    },
+    "node_modules/@semantic-release/git/node_modules/@semantic-release/error": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@semantic-release/github": {
@@ -874,15 +895,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=24.1.0"
-      }
-    },
-    "node_modules/@semantic-release/github/node_modules/@semantic-release/error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@semantic-release/github/node_modules/aggregate-error": {
@@ -965,15 +977,6 @@
       },
       "peerDependencies": {
         "semantic-release": ">=20.1.0"
-      }
-    },
-    "node_modules/@semantic-release/npm/node_modules/@semantic-release/error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@semantic-release/npm/node_modules/aggregate-error": {
@@ -9449,15 +9452,6 @@
         "node": ">=20.8.1"
       }
     },
-    "node_modules/semantic-release/node_modules/@semantic-release/error": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/semantic-release/node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -11801,6 +11795,14 @@
         "aggregate-error": "^3.0.0",
         "fs-extra": "^11.0.0",
         "lodash": "^4.17.4"
+      },
+      "dependencies": {
+        "@semantic-release/error": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "dev": true
+        }
       }
     },
     "@semantic-release/commit-analyzer": {
@@ -11820,10 +11822,9 @@
       }
     },
     "@semantic-release/error": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-      "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
+      "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ=="
     },
     "@semantic-release/git": {
       "version": "10.0.1",
@@ -11839,6 +11840,14 @@
         "lodash": "^4.17.4",
         "micromatch": "^4.0.0",
         "p-reduce": "^2.0.0"
+      },
+      "dependencies": {
+        "@semantic-release/error": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
+          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw==",
+          "dev": true
+        }
       }
     },
     "@semantic-release/github": {
@@ -11865,12 +11874,6 @@
         "url-join": "^5.0.0"
       },
       "dependencies": {
-        "@semantic-release/error": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-          "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-          "dev": true
-        },
         "aggregate-error": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
@@ -11925,12 +11928,6 @@
         "tempy": "^3.0.0"
       },
       "dependencies": {
-        "@semantic-release/error": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-          "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-          "dev": true
-        },
         "aggregate-error": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-5.0.0.tgz",
@@ -17827,12 +17824,6 @@
         "yargs": "^17.5.1"
       },
       "dependencies": {
-        "@semantic-release/error": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-4.0.0.tgz",
-          "integrity": "sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==",
-          "dev": true
-        },
         "@sindresorhus/merge-streams": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "*.cjs": "eslint"
   },
   "dependencies": {
-    "@adobe/fetch": "4.2.2"
+    "@adobe/fetch": "4.2.2",
+    "@semantic-release/error": "4.0.0"
   }
 }

--- a/src/coralogix-tagger.js
+++ b/src/coralogix-tagger.js
@@ -9,7 +9,6 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-
 let fetchContext;
 
 async function getOrCreateFetchContext() {
@@ -53,7 +52,9 @@ async function tag({
   if (res.ok) {
     return true;
   }
-  throw new Error(`${await res.text()} ${res.status}`);
+  const module = await import('@semantic-release/error');
+  const SemanticReleaseError = module.default;
+  throw new SemanticReleaseError(`${await res.text()} ${res.status}`);
 }
 
 async function verifytoken({ hostname = 'coralogix.com', API_KEY }) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,7 +76,7 @@ describe('Publish Test', () => {
       .post('/api/v1/external/tags')
       .reply(500);
 
-    await assert.rejects(publish({}, { nextRelease: { version: '2.0.0' }, logger: console }));
+    await assert.rejects(publish({}, { nextRelease: { version: '2.0.0' }, logger: console }), /500/);
 
     assert.ok(scope.isDone());
   });


### PR DESCRIPTION
According to [Handling Errors](https://semantic-release.gitbook.io/semantic-release/developer-guide/plugin#handling-errors) plugins should throw a `SemanticReleaseError` in later stages, so `semantic-release` will still invoke the `fail` stage for prepared plugins.